### PR TITLE
fix subdirs of tests/ being included in the report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,7 +12,7 @@ ignore_errors = True
 omit =
     setup.py
     */tests.py
-    */tests/*.py
+    */tests/**/*.py
     */migrations/*
     doc/*
     */scripts/*


### PR DESCRIPTION
## Description

Currently if there are test files in a subdir of tests/ they'd be included in the report. For example:

```
tests/
    dir_a/
        test_a.py
    test_b.py
```

in this scenario, `tests/dir_a/test_a.py` would be included in the coverage report.

## Type of Change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
